### PR TITLE
Make site.url protocol independent.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,2 +1,2 @@
-url: http://taglib.github.com/
+url: //taglib.github.com/
 permalink: none


### PR DESCRIPTION
Current resources like the Bootstrap CSS are served via http. This breaks
Browser/Extensions that deny unsecure resources in some way. Changing
the include syntax in link/img/.. tags to the protocol independent
version '//' (instead of 'http://') will always load the resources via
the same protocol as the page they are loaded from.
