### PR TITLE
Point to my maintained fork of tagpy

### DIFF
--- a/index.markdown
+++ b/index.markdown
@@ -101,7 +101,7 @@ CMake. Most Linux distributions ship with TagLib already.
   [API documentation]: https://taglib.org/api/
   [development list]: https://mail.kde.org/mailman/listinfo/taglib-devel
   [Perl]: https://metacpan.org/release/Audio-TagLib
-  [TagPy]: https://mathema.tician.de/software/tagpy/
+  [TagPy]: https://github.com/palfrey/tagpy
   [pytaglib]: https://github.com/supermihi/pytaglib
   [taglib-ruby]: https://robinst.github.io/taglib-ruby/
   [taglib-rust]: https://ebassi.github.io/taglib-rust/


### PR DESCRIPTION
https://mathema.tician.de/software/tagpy/ points to https://github.com/inducer/tagpy which is now archived, and flags my fork as the maintained one. I'm also (via that fork) the maintainer of https://pypi.org/project/tagpy/ which was handed over to me by the original maintainer.